### PR TITLE
Add DetailsMap() to protocol interface

### DIFF
--- a/xray/protocols.go
+++ b/xray/protocols.go
@@ -2,8 +2,11 @@ package xray
 
 import (
 	"errors"
-	"github.com/xtls/xray-core/infra/conf"
+	"fmt"
 	"strings"
+
+	"github.com/fatih/color"
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 const (
@@ -21,6 +24,24 @@ type Protocol interface {
 	BuildInboundDetourConfig() (*conf.InboundDetourConfig, error)
 	DetailsStr() string
 	ConvertToGeneralConfig() GeneralConfig
+}
+
+func detailsToStr(details [][2]string) string {
+	result := ""
+	for _, d := range details {
+		result += fmt.Sprintf("%s: %s\n", color.RedString(d[0]), d[1])
+	}
+
+	return result
+}
+
+func detailsToMap(details [][2]string) map[string]string {
+	result := make(map[string]string, len(details))
+	for _, d := range details {
+		result[d[0]] = d[1]
+	}
+
+	return result
 }
 
 func CreateProtocol(configLink string) (Protocol, error) {
@@ -82,10 +103,10 @@ type Vmess struct {
 	TlsFingerprint string      `json:"fp"`   // TLS fingerprint
 	Type           string      `json:"type"` // Used for HTTP Obfuscation
 
-	//// It's also possible for Vmess to have REALITY...
-	//PublicKey string `json:"pbk"`
-	//ShortIds  string `json:"sid"` // Mandatory, the shortId list available to the client, which can be used to distinguish different clients
-	//SpiderX   string `json:"spx"` // Reality path
+	// // It's also possible for Vmess to have REALITY...
+	// PublicKey string `json:"pbk"`
+	// ShortIds  string `json:"sid"` // Mandatory, the shortId list available to the client, which can be used to distinguish different clients
+	// SpiderX   string `json:"spx"` // Reality path
 
 	OrigLink string `json:"-"` // Original link
 }

--- a/xray/protocols.go
+++ b/xray/protocols.go
@@ -23,6 +23,7 @@ type Protocol interface {
 	BuildOutboundDetourConfig(allowInsecure bool) (*conf.OutboundDetourConfig, error)
 	BuildInboundDetourConfig() (*conf.InboundDetourConfig, error)
 	DetailsStr() string
+	DetailsMap() map[string]string
 	ConvertToGeneralConfig() GeneralConfig
 }
 

--- a/xray/shadowsocks.go
+++ b/xray/shadowsocks.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/utils"
 	"github.com/xtls/xray-core/infra/conf"
+
+	"github.com/lilendian0x00/xray-knife/v2/utils"
 )
 
 func NewShadowsocks() Protocol {
@@ -44,11 +44,11 @@ func (s *Shadowsocks) Parse(configLink string) error {
 		return errors.New("invalid config link")
 	}
 
-	//link := "ss://" + string(decoded) + "@" + secondPart[1]
-	//uri, err := url.Parse(link)
-	//if err != nil {
+	// link := "ss://" + string(decoded) + "@" + secondPart[1]
+	// uri, err := url.Parse(link)
+	// if err != nil {
 	//	return err
-	//}
+	// }
 	creds := strings.SplitN(string(decoded), ":", 2)
 	if len(creds) != 2 {
 		return errors.New("error when decoding secret part")
@@ -57,7 +57,7 @@ func (s *Shadowsocks) Parse(configLink string) error {
 	s.Encryption = creds[0] // Encryption Type
 	s.Password = creds[1]   // Encryption Password
 
-	//hostPortRemark := strings.SplitN(secondPart[1], ":", 2)
+	// hostPortRemark := strings.SplitN(secondPart[1], ":", 2)
 
 	s.Address, s.Port, err = net.SplitHostPort(uri.Host)
 	if err != nil {
@@ -73,31 +73,31 @@ func (s *Shadowsocks) Parse(configLink string) error {
 		s.Remark = uri.Fragment
 	}
 
-	//s.Address = hostPortRemark[0]
+	// s.Address = hostPortRemark[0]
 	//
-	//PortRemark := strings.SplitN(hostPortRemark[1], "#", 2)
-	//s.Port = PortRemark[0]
+	// PortRemark := strings.SplitN(hostPortRemark[1], "#", 2)
+	// s.Port = PortRemark[0]
 
-	//remarkStr, _, _ := strings.Cut(PortRemark[1], "\n")
+	// remarkStr, _, _ := strings.Cut(PortRemark[1], "\n")
 
-	//s.Remark, err = url.PathUnescape(remarkStr)
-	//if err != nil {
+	// s.Remark, err = url.PathUnescape(remarkStr)
+	// if err != nil {
 	//	s.Remark = remarkStr
-	//}
+	// }
 	s.OrigLink = configLink
 
 	return nil
 }
 
 func (s *Shadowsocks) DetailsStr() string {
-	info := fmt.Sprintf("%s: %s\n%s: %s\n%s: %s\n%s: %v\n%s: %s\n%s: %s\n",
-		color.RedString("Protocol"), s.Name(),
-		color.RedString("Remark"), s.Remark,
-		color.RedString("IP"), s.Address,
-		color.RedString("Port"), s.Port,
-		color.RedString("Encryption"), s.Encryption,
-		color.RedString("Password"), s.Password)
-	return info
+	return detailsToStr([][2]string{
+		{"Protocol", s.Name()},
+		{"Remark", s.Remark},
+		{"IP", s.Address},
+		{"Port", s.Port},
+		{"Encryption", s.Encryption},
+		{"Password", s.Password},
+	})
 }
 
 func (s *Shadowsocks) ConvertToGeneralConfig() GeneralConfig {

--- a/xray/shadowsocks.go
+++ b/xray/shadowsocks.go
@@ -90,14 +90,22 @@ func (s *Shadowsocks) Parse(configLink string) error {
 }
 
 func (s *Shadowsocks) DetailsStr() string {
-	return detailsToStr([][2]string{
+	return detailsToStr(s.details())
+}
+
+func (s *Shadowsocks) DetailsMap() map[string]string {
+	return detailsToMap(s.details())
+}
+
+func (s *Shadowsocks) details() [][2]string {
+	return [][2]string{
 		{"Protocol", s.Name()},
 		{"Remark", s.Remark},
 		{"IP", s.Address},
 		{"Port", s.Port},
 		{"Encryption", s.Encryption},
 		{"Password", s.Password},
-	})
+	}
 }
 
 func (s *Shadowsocks) ConvertToGeneralConfig() GeneralConfig {

--- a/xray/shadowsocks_test.go
+++ b/xray/shadowsocks_test.go
@@ -8,5 +8,17 @@ func TestShadowSocks_Parse(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error when parsing: %v", err)
 	}
+
+	expected := `Protocol: shadowsocks
+Remark: exa
+IP: example.com
+Port: 443
+Encryption: aes-256-gcm
+Password: Example@1234
+`
+
 	t.Logf("%s\n", ss.DetailsStr())
+	if expected != ss.DetailsStr() {
+		t.Fatalf("expected %q, got %q", expected, ss.DetailsStr())
+	}
 }

--- a/xray/shadowsocks_test.go
+++ b/xray/shadowsocks_test.go
@@ -1,6 +1,9 @@
 package xray
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestShadowSocks_Parse(t *testing.T) {
 	var ss Shadowsocks
@@ -20,5 +23,18 @@ Password: Example@1234
 	t.Logf("%s\n", ss.DetailsStr())
 	if expected != ss.DetailsStr() {
 		t.Fatalf("expected %q, got %q", expected, ss.DetailsStr())
+	}
+
+	expectedMap := map[string]string{
+		"Protocol":   "shadowsocks",
+		"Remark":     "exa",
+		"IP":         "example.com",
+		"Port":       "443",
+		"Encryption": "aes-256-gcm",
+		"Password":   "Example@1234",
+	}
+
+	if !reflect.DeepEqual(expectedMap, ss.DetailsMap()) {
+		t.Fatalf("expected %v, got %v", expectedMap, ss.DetailsMap())
 	}
 }

--- a/xray/socks.go
+++ b/xray/socks.go
@@ -53,6 +53,14 @@ func (s *Socks) Parse(configLink string) error {
 }
 
 func (s *Socks) DetailsStr() string {
+	return detailsToStr(s.details())
+}
+
+func (s *Socks) DetailsMap() map[string]string {
+	return detailsToMap(s.details())
+}
+
+func (s *Socks) details() [][2]string {
 	copyV := *s
 	result := [][2]string{
 		{"Protocol", s.Name()},
@@ -69,7 +77,7 @@ func (s *Socks) DetailsStr() string {
 		}...)
 	}
 
-	return detailsToStr(result)
+	return result
 }
 
 func (s *Socks) ConvertToGeneralConfig() GeneralConfig {

--- a/xray/socks.go
+++ b/xray/socks.go
@@ -9,10 +9,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/utils"
 	net2 "github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/infra/conf"
+
+	"github.com/lilendian0x00/xray-knife/v2/utils"
 )
 
 func NewSocks() Protocol {
@@ -54,22 +54,22 @@ func (s *Socks) Parse(configLink string) error {
 
 func (s *Socks) DetailsStr() string {
 	copyV := *s
-
-	info := fmt.Sprintf("%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %v\n",
-		color.RedString("Protocol"), s.Name(),
-		color.RedString("Remark"), copyV.Remark,
-		color.RedString("Network"), "tcp",
-		color.RedString("Address"), copyV.Address,
-		color.RedString("Port"), copyV.Port,
-	)
-
-	if len(copyV.Username) != 0 && len(copyV.Password) != 0 {
-		info += color.RedString("Username") + ": " + copyV.Username
-		info += "\n"
-		info += color.RedString("Password") + ": " + copyV.Password
+	result := [][2]string{
+		{"Protocol", s.Name()},
+		{"Remark", copyV.Remark},
+		{"Network", "tcp"},
+		{"Address", copyV.Address},
+		{"Port", copyV.Port},
 	}
 
-	return info
+	if len(copyV.Username) != 0 && len(copyV.Password) != 0 {
+		result = append(result, [][2]string{
+			{"Username", copyV.Username},
+			{"Password", copyV.Password},
+		}...)
+	}
+
+	return detailsToStr(result)
 }
 
 func (s *Socks) ConvertToGeneralConfig() GeneralConfig {

--- a/xray/trojan.go
+++ b/xray/trojan.go
@@ -93,6 +93,14 @@ func (t *Trojan) Parse(configLink string) error {
 }
 
 func (t *Trojan) DetailsStr() string {
+	return detailsToStr(t.details())
+}
+
+func (t *Trojan) DetailsMap() map[string]string {
+	return detailsToMap(t.details())
+}
+
+func (t *Trojan) details() [][2]string {
 	copyV := *t
 	if copyV.Flow == "" || copyV.Type == "grpc" {
 		copyV.Flow = "none"
@@ -163,7 +171,7 @@ func (t *Trojan) DetailsStr() string {
 		result = append(result, [2]string{"TLS", "none"})
 	}
 
-	return detailsToStr(result)
+	return result
 }
 
 func (t *Trojan) ConvertToGeneralConfig() GeneralConfig {

--- a/xray/trojan_test.go
+++ b/xray/trojan_test.go
@@ -1,6 +1,9 @@
 package xray
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestTrojan_Parse(t *testing.T) {
 	var ss Trojan
@@ -27,5 +30,25 @@ Fingerprint: chrome
 	t.Logf("%s\n", ss.DetailsStr())
 	if expected != ss.DetailsStr() {
 		t.Fatalf("expected %q, got %q", expected, ss.DetailsStr())
+	}
+
+	expectedMap := map[string]string{
+		"Protocol":    "trojan",
+		"Remark":      "exa",
+		"Network":     "grpc",
+		"Address":     "1.1.1.1",
+		"Port":        "80",
+		"Password":    "fsdfsgfgdfgdfg",
+		"Flow":        "none",
+		"ServiceName": "/gdfgdgdfgdfgdfgfg",
+		"Authority":   "",
+		"TLS":         "tls",
+		"SNI":         "example.com",
+		"ALPN":        "h2,http/1.1",
+		"Fingerprint": "chrome",
+	}
+
+	if !reflect.DeepEqual(expectedMap, ss.DetailsMap()) {
+		t.Fatalf("expected %v, got %v", expectedMap, ss.DetailsMap())
 	}
 }

--- a/xray/trojan_test.go
+++ b/xray/trojan_test.go
@@ -8,5 +8,24 @@ func TestTrojan_Parse(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error when parsing: %v", err)
 	}
+
+	expected := `Protocol: trojan
+Remark: exa
+Network: grpc
+Address: 1.1.1.1
+Port: 80
+Password: fsdfsgfgdfgdfg
+Flow: none
+ServiceName: /gdfgdgdfgdfgdfgfg
+Authority: 
+TLS: tls
+SNI: example.com
+ALPN: h2,http/1.1
+Fingerprint: chrome
+`
+
 	t.Logf("%s\n", ss.DetailsStr())
+	if expected != ss.DetailsStr() {
+		t.Fatalf("expected %q, got %q", expected, ss.DetailsStr())
+	}
 }

--- a/xray/vless.go
+++ b/xray/vless.go
@@ -92,6 +92,14 @@ func (v *Vless) Parse(configLink string) error {
 }
 
 func (v *Vless) DetailsStr() string {
+	return detailsToStr(v.details())
+}
+
+func (v *Vless) DetailsMap() map[string]string {
+	return detailsToMap(v.details())
+}
+
+func (v *Vless) details() [][2]string {
 	copyV := *v
 	if copyV.Flow == "" || copyV.Type == "grpc" {
 		copyV.Flow = "none"
@@ -166,7 +174,7 @@ func (v *Vless) DetailsStr() string {
 		result = append(result, [2]string{"TLS", "tls"})
 	}
 
-	return detailsToStr(result)
+	return result
 }
 
 func (v *Vless) ConvertToGeneralConfig() GeneralConfig {

--- a/xray/vless_test.go
+++ b/xray/vless_test.go
@@ -1,0 +1,33 @@
+package xray
+
+import (
+	"testing"
+)
+
+func TestVless_Parse(t *testing.T) {
+	var v Vless
+	err := v.Parse("vless://h1px412i-9138-s9m5-9b86-d47d74dd8541@127.0.0.1:8080?type=tcp&security=reality&pbk=4442383675fc0fb574c3e50abbe7d4c5&fp=chrome&sni=yahoo.com&sid=0c&spx=%2F&flow=xtls-rprx-vision#Myremark")
+	if err != nil {
+		t.Errorf("Error when parsing: %v", err)
+	}
+
+	expected := `Protocol: vless
+Remark: Myremark
+Network: tcp
+Address: 127.0.0.1
+Port: 8080
+UUID: h1px412i-9138-s9m5-9b86-d47d74dd8541
+Flow: xtls-rprx-vision
+TLS: reality
+Public key: 4442383675fc0fb574c3e50abbe7d4c5
+SNI: yahoo.com
+ShortID: 0c
+SpiderX: /
+Fingerprint: chrome
+`
+
+	t.Logf("%s\n", v.DetailsStr())
+	if expected != v.DetailsStr() {
+		t.Fatalf("expected %q, got %q", expected, v.DetailsStr())
+	}
+}

--- a/xray/vless_test.go
+++ b/xray/vless_test.go
@@ -1,6 +1,7 @@
 package xray
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -29,5 +30,25 @@ Fingerprint: chrome
 	t.Logf("%s\n", v.DetailsStr())
 	if expected != v.DetailsStr() {
 		t.Fatalf("expected %q, got %q", expected, v.DetailsStr())
+	}
+
+	expectedMap := map[string]string{
+		"Protocol":    "vless",
+		"Remark":      "Myremark",
+		"Network":     "tcp",
+		"Address":     "127.0.0.1",
+		"Port":        "8080",
+		"UUID":        "h1px412i-9138-s9m5-9b86-d47d74dd8541",
+		"Flow":        "xtls-rprx-vision",
+		"TLS":         "reality",
+		"Public key":  "4442383675fc0fb574c3e50abbe7d4c5",
+		"SNI":         "yahoo.com",
+		"ShortID":     "0c",
+		"SpiderX":     "/",
+		"Fingerprint": "chrome",
+	}
+
+	if !reflect.DeepEqual(expectedMap, v.DetailsMap()) {
+		t.Fatalf("expected %v, got %v", expectedMap, v.DetailsMap())
 	}
 }

--- a/xray/vmess.go
+++ b/xray/vmess.go
@@ -139,6 +139,14 @@ func (v *Vmess) Parse(configLink string) error {
 }
 
 func (v *Vmess) DetailsStr() string {
+	return detailsToStr(v.details())
+}
+
+func (v *Vmess) DetailsMap() map[string]string {
+	return detailsToMap(v.details())
+}
+
+func (v *Vmess) details() [][2]string {
 	copyV := *v
 	result := make([][2]string, 0, 20)
 
@@ -201,7 +209,7 @@ func (v *Vmess) DetailsStr() string {
 		}...)
 	}
 
-	return detailsToStr(result)
+	return result
 }
 
 func (v *Vmess) ConvertToGeneralConfig() GeneralConfig {

--- a/xray/vmess_test.go
+++ b/xray/vmess_test.go
@@ -1,0 +1,30 @@
+package xray
+
+import (
+	"testing"
+)
+
+func TestVmess_Parse(t *testing.T) {
+	var v Vmess
+	err := v.Parse("vmess://ewogICJ2IjogIjIiLAogICJwcyI6ICJUZXN0cmVtYXJrLWIyc2x4bWZpIiwKICAiYWRkIjogIjEyNy4wLjAuMSIsCiAgInBvcnQiOiAyNjYzNSwKICAiaWQiOiAiOTMwZTk0NDQtYzU1ZC00YjcyLTk0NTUtYjk4MTE2ZGFhNGIzIiwKICAic2N5IjogImF1dG8iLAogICJuZXQiOiAidGNwIiwKICAidHlwZSI6ICJub25lIiwKICAidGxzIjogInRscyIKfQ==")
+	if err != nil {
+		t.Errorf("Error when parsing: %v", err)
+	}
+
+	expected := `Protocol: vmess
+Remark: Testremark-b2slxmfi
+Network: tcp
+Address: 127.0.0.1
+Port: 26635
+UUID: 930e9444-c55d-4b72-9455-b98116daa4b3
+TLS: tls
+SNI: none
+ALPN: none
+Fingerprint: none
+`
+
+	t.Logf("%s\n", v.DetailsStr())
+	if expected != v.DetailsStr() {
+		t.Fatalf("expected %q, got %q", expected, v.DetailsStr())
+	}
+}

--- a/xray/vmess_test.go
+++ b/xray/vmess_test.go
@@ -1,6 +1,7 @@
 package xray
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -26,5 +27,22 @@ Fingerprint: none
 	t.Logf("%s\n", v.DetailsStr())
 	if expected != v.DetailsStr() {
 		t.Fatalf("expected %q, got %q", expected, v.DetailsStr())
+	}
+
+	expectedMap := map[string]string{
+		"Protocol":    "vmess",
+		"Remark":      "Testremark-b2slxmfi",
+		"Network":     "tcp",
+		"Address":     "127.0.0.1",
+		"Port":        "26635",
+		"UUID":        "930e9444-c55d-4b72-9455-b98116daa4b3",
+		"TLS":         "tls",
+		"SNI":         "none",
+		"ALPN":        "none",
+		"Fingerprint": "none",
+	}
+
+	if !reflect.DeepEqual(expectedMap, v.DetailsMap()) {
+		t.Fatalf("expected %v, got %v", expectedMap, v.DetailsMap())
 	}
 }

--- a/xray/wireguard.go
+++ b/xray/wireguard.go
@@ -3,11 +3,11 @@ package xray
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/xtls/xray-core/infra/conf"
 	"net/url"
 	"reflect"
 	"strings"
+
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 func NewWireguard() Protocol {
@@ -74,17 +74,17 @@ func (w *Wireguard) Parse(configLink string) error {
 }
 
 func (w *Wireguard) DetailsStr() string {
-	info := fmt.Sprintf("%s: %s\n%s: %s\n%s: %s\n%s: %d\n%s: %s\n%s: %v\n%s: %s\n", w.Name(),
-		color.RedString("Protocol"),
-		color.RedString("Remark"), w.Remark,
-		color.RedString("Endpoint"), w.Endpoint,
-		color.RedString("MTU"), w.Mtu,
-		color.RedString("Local Addresses"), w.LocalAddress,
-		color.RedString("Public Key"), w.PublicKey,
-		color.RedString("Secret Key"), w.SecretKey,
-	)
+	details := [][2]string{
+		{"Protocol", w.Name()},
+		{"Remark", w.Remark},
+		{"Endpoint", w.Endpoint},
+		{"MTU", fmt.Sprintf("%d", w.Mtu)},
+		{"Local Addresses", w.LocalAddress},
+		{"Public Key", w.PublicKey},
+		{"Secret Key", w.SecretKey},
+	}
 
-	return info
+	return detailsToStr(details)
 }
 
 func (w *Wireguard) ConvertToGeneralConfig() GeneralConfig {
@@ -100,7 +100,7 @@ func (w *Wireguard) BuildOutboundDetourConfig(allowInsecure bool) (*conf.Outboun
 	out.Tag = "proxy"
 	out.Protocol = w.Name()
 
-	//c := conf.WireGuardConfig{
+	// c := conf.WireGuardConfig{
 	//	IsClient:   true,
 	//	KernelMode: nil,
 	//	SecretKey:  w.SecretKey,
@@ -116,7 +116,7 @@ func (w *Wireguard) BuildOutboundDetourConfig(allowInsecure bool) (*conf.Outboun
 	//	},
 	//	MTU:            w.Mtu,
 	//	DomainStrategy: "ForceIPv6v4",
-	//}
+	// }
 
 	oset := json.RawMessage([]byte(fmt.Sprintf(`{
   "secretKey": "%s",

--- a/xray/wireguard.go
+++ b/xray/wireguard.go
@@ -74,7 +74,15 @@ func (w *Wireguard) Parse(configLink string) error {
 }
 
 func (w *Wireguard) DetailsStr() string {
-	details := [][2]string{
+	return detailsToStr(w.details())
+}
+
+func (w *Wireguard) DetailsMap() map[string]string {
+	return detailsToMap(w.details())
+}
+
+func (w *Wireguard) details() [][2]string {
+	return [][2]string{
 		{"Protocol", w.Name()},
 		{"Remark", w.Remark},
 		{"Endpoint", w.Endpoint},
@@ -83,8 +91,6 @@ func (w *Wireguard) DetailsStr() string {
 		{"Public Key", w.PublicKey},
 		{"Secret Key", w.SecretKey},
 	}
-
-	return detailsToStr(details)
 }
 
 func (w *Wireguard) ConvertToGeneralConfig() GeneralConfig {


### PR DESCRIPTION
I think this one is pretty handy and helpful for a lot of cases and should be here alongside the DetailsStr() method.

Updated DetailsStr is backward compatible and will output exactly the same string as before.