### PR TITLE
Various bug-fixes, runtime crash fixes and refactoring of code

### DIFF
--- a/cmd/net/glob_vars.go
+++ b/cmd/net/glob_vars.go
@@ -3,4 +3,3 @@ package net
 var (
 	configLink string
 )
-

--- a/cmd/net/http.go
+++ b/cmd/net/http.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/fatih/color"
-	"github.com/gocarina/gocsv"
 	"github.com/lilendian0x00/xray-knife/v2/pkg"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
 	"github.com/lilendian0x00/xray-knife/v2/utils/customlog"
+
+	"github.com/fatih/color"
+	"github.com/gocarina/gocsv"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/net/icmp.go
+++ b/cmd/net/icmp.go
@@ -3,14 +3,15 @@ package net
 import (
 	"bufio"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"net"
 	"os"
 	"strings"
 
 	"github.com/lilendian0x00/xray-knife/v2/network"
+	"github.com/lilendian0x00/xray-knife/v2/pkg"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/pkg/xray"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/net/tcp.go
+++ b/cmd/net/tcp.go
@@ -1,11 +1,11 @@
 package net
 
 import (
-	"github.com/lilendian0x00/xray-knife/v2/pkg/xray"
 	"net"
 	"os"
 	"time"
 
+	"github.com/lilendian0x00/xray-knife/v2/pkg/xray"
 	"github.com/lilendian0x00/xray-knife/v2/utils/customlog"
 
 	"github.com/spf13/cobra"

--- a/cmd/parse/parse.go
+++ b/cmd/parse/parse.go
@@ -3,12 +3,13 @@ package parse
 import (
 	"bufio"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg"
 	"os"
 	"time"
-	
-	"github.com/fatih/color"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/parse/parse.go
+++ b/cmd/parse/parse.go
@@ -4,13 +4,9 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/lilendian0x00/xray-knife/v2/pkg"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"log"
-	"net/url"
 	"os"
-	"strings"
 	"time"
-
+	
 	"github.com/fatih/color"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
 	"github.com/spf13/cobra"
@@ -33,72 +29,37 @@ var ParseCmd = &cobra.Command{
 			return
 		}
 
-		xrayCore := pkg.CoreFactory(pkg.XrayCoreType, false, false)
-		singboxCore := pkg.CoreFactory(pkg.SingboxCoreType, false, false)
-		SelectedCore := map[string]pkg.Core{
-			protocol.VmessIdentifier:       xrayCore,
-			protocol.VlessIdentifier:       xrayCore,
-			protocol.ShadowsocksIdentifier: xrayCore,
-			protocol.TrojanIdentifier:      xrayCore,
-			protocol.SocksIdentifier:       singboxCore,
-			protocol.WireguardIdentifier:   singboxCore,
-			protocol.Hysteria2Identifier:   singboxCore,
-			"hy2":                          singboxCore,
-		}
-
-		var core pkg.Core
+		core := pkg.NewAutomaticCore(true, true)
+		var links []string
 
 		if readFromSTDIN {
 			reader := bufio.NewReader(os.Stdin)
 			fmt.Println("Enter your config link:")
 			text, _ := reader.ReadString('\n')
-			configLink = text
-
+			links = append(links, text)
+		} else if configLink != "" {
+			links = append(links, configLink)
 		} else if configLinksFile != "" {
-			links := utils.ParseFileByNewline(configLinksFile)
+			links = utils.ParseFileByNewline(configLinksFile)
 			//fmt.Println(links)
-			d := color.New(color.FgCyan, color.Bold)
-			for i, link := range links {
-				d.Printf("Config Number: %d\n", i+1)
-				protocol, err := core.CreateProtocol(link)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%v", err)
-					os.Exit(1)
-				}
-				fmt.Println(protocol.DetailsStr() + "\n")
-				time.Sleep(time.Duration(25) * time.Millisecond)
-			}
-			return
-
 		}
 
-		if readFromSTDIN || configLink != "" {
-			// Remove any spaces
-			configLink = strings.TrimSpace(configLink)
-
-			uri, err := url.Parse(configLink)
-			if err != nil {
-				log.Fatalf("Couldn't parse the config: %v\n", err)
-			}
-
-			coreAuto, ok := SelectedCore[uri.Scheme]
-			if !ok {
-				log.Fatalln("Couldn't parse the config: invalid protocol")
+		d := color.New(color.FgCyan, color.Bold)
+		for i, link := range links {
+			if len(links) > 1 {
+				d.Printf("Config Number: %d", i+1)
 			}
 
 			fmt.Printf("\n")
-			p, err := coreAuto.CreateProtocol(configLink)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "%v", err)
-				os.Exit(1)
-			}
-			err = p.Parse()
+			p, err := core.CreateProtocol(link)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "%v", err)
 				os.Exit(1)
 			}
 
 			fmt.Println(p.DetailsStr())
+
+			time.Sleep(time.Duration(25) * time.Millisecond)
 		}
 	},
 }

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -29,7 +29,7 @@ var (
 	readConfigFromSTDIN bool
 	listenAddr          string
 	listenPort          string
-	link                string
+	configLink          string
 	verbose             bool
 	insecureTLS         bool
 	chainOutbounds      bool
@@ -42,7 +42,7 @@ var ProxyCmd = &cobra.Command{
 	Short: "Creates proxy server",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) < 1 && (!readConfigFromSTDIN && link == "" && configLinksFile == "") {
+		if len(args) < 1 && (!readConfigFromSTDIN && configLink == "" && configLinksFile == "") {
 			cmd.Help()
 			return
 		}
@@ -82,16 +82,16 @@ var ProxyCmd = &cobra.Command{
 		var links []string
 		var configs []protocol.Protocol
 
-		if configLinksFile != "" {
-			// Get configs from file
-			links = utils.ParseFileByNewline(configLinksFile)
-
-		} else if readConfigFromSTDIN {
-			// Get config from STDIN
+		if readConfigFromSTDIN {
 			reader := bufio.NewReader(os.Stdin)
 			fmt.Println("Reading config from STDIN:")
-			link, _ = reader.ReadString('\n')
-			links = append(links, link)
+			text, _ := reader.ReadString('\n')
+			links = append(links, text)
+		} else if configLink != "" {
+			links = append(links, configLink)
+		} else if configLinksFile != "" {
+			links = utils.ParseFileByNewline(configLinksFile)
+			//fmt.Println(links)
 		}
 
 		// Parse all the links
@@ -284,6 +284,7 @@ var ProxyCmd = &cobra.Command{
 			}
 		} else {
 			// Configuring outbound
+			link := links[0]
 			outboundParsed, err := core.CreateProtocol(link)
 			if err != nil {
 				log.Fatalf("Couldn't parse the config : %v", err)
@@ -326,7 +327,7 @@ func init() {
 
 	ProxyCmd.Flags().StringVarP(&listenAddr, "addr", "a", "127.0.0.1", "Listen ip address")
 	ProxyCmd.Flags().StringVarP(&listenPort, "port", "p", "9999", "Listen port number")
-	ProxyCmd.Flags().StringVarP(&link, "config", "c", "", "The xray config link")
+	ProxyCmd.Flags().StringVarP(&configLink, "config", "c", "", "The xray config link")
 
 	ProxyCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Verbose xray-core")
 	ProxyCmd.Flags().BoolVarP(&insecureTLS, "insecure", "e", false, "Insecure tls connection (fake SNI)")

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -3,10 +3,6 @@ package proxy
 import (
 	"bufio"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/singbox"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/xray"
 	"log"
 	"math/rand"
 	"os"
@@ -15,10 +11,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/lilendian0x00/xray-knife/v2/cmd/net"
+	"github.com/lilendian0x00/xray-knife/v2/pkg"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/singbox"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/xray"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
 	"github.com/lilendian0x00/xray-knife/v2/utils/customlog"
+
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -158,6 +158,9 @@ var ProxyCmd = &cobra.Command{
 			//var currentIndex int
 			//var lastIndex int
 
+			config := &net.Config{}
+			processor := net.NewResultProcessor(config)
+
 			customlog.Printf(customlog.Processing, "Looking for a working outbound config...\n")
 
 			connect := func() {
@@ -173,7 +176,7 @@ var ProxyCmd = &cobra.Command{
 					// Shuffle all links
 					r.Shuffle(len(links), func(i, j int) { links[i], links[j] = links[j], links[i] })
 
-					testManager := net.NewTestManager(examiner, nil, 50, false)
+					testManager := net.NewTestManager(examiner, processor, 50, false)
 					results := testManager.TestConfigs(links[0 : testCount-1])
 					sort.Sort(results)
 					for _, v := range results {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
-	"github.com/lilendian0x00/xray-knife/v2/cmd/proxy"
 	"os"
 
 	"github.com/lilendian0x00/xray-knife/v2/cmd/net"
 	"github.com/lilendian0x00/xray-knife/v2/cmd/parse"
+	"github.com/lilendian0x00/xray-knife/v2/cmd/proxy"
 	"github.com/lilendian0x00/xray-knife/v2/cmd/scan"
 	"github.com/lilendian0x00/xray-knife/v2/cmd/subs"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/subs/fetch.go
+++ b/cmd/subs/fetch.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lilendian0x00/xray-knife/v2/utils"
 	"github.com/lilendian0x00/xray-knife/v2/utils/customlog"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/subs/subscription.go
+++ b/cmd/subs/subscription.go
@@ -1,7 +1,6 @@
 package subs
 
 import (
-	"github.com/imroc/req/v3"
 	"io"
 	"log"
 	"net/url"
@@ -9,6 +8,8 @@ import (
 
 	"github.com/lilendian0x00/xray-knife/v2/utils"
 	"github.com/lilendian0x00/xray-knife/v2/utils/customlog"
+
+	"github.com/imroc/req/v3"
 )
 
 // TODO: Make a database to store subscriptions

--- a/network/icmp.go
+++ b/network/icmp.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/lilendian0x00/xray-knife/v2/utils/customlog"
+
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 )

--- a/pkg/coreFactory.go
+++ b/pkg/coreFactory.go
@@ -1,14 +1,15 @@
 package pkg
 
 import (
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/singbox"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/xray"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/singbox"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/xray"
 )
 
 type CoreType uint8

--- a/pkg/examiner.go
+++ b/pkg/examiner.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"io"
 	"net/http"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/speedtester/cloudflare"
 )
 

--- a/pkg/examiner.go
+++ b/pkg/examiner.go
@@ -190,7 +190,7 @@ func (e *Examiner) ExamineConfig(link string) (Result, error) {
 	if err != nil {
 		r.Status = "broken"
 		r.Reason = err.Error()
-		return r, nil
+		return r, err
 	}
 	// Close xray conn after testing
 	defer instance.Close()
@@ -204,7 +204,7 @@ func (e *Examiner) ExamineConfig(link string) (Result, error) {
 		//customlog.Printf(customlog.Failure, "Config didn't respond!\n\n")
 		r.Status = "failed"
 		r.Reason = err.Error()
-		return r, nil
+		return r, err
 		//os.Exit(1)
 	}
 	r.Delay = delay
@@ -217,7 +217,7 @@ func (e *Examiner) ExamineConfig(link string) (Result, error) {
 
 	if uint16(delay) > e.MaxDelay {
 		r.Status = "timeout"
-		return r, nil
+		return r, errors.New("timeout")
 	}
 
 	if e.DoIPInfo {

--- a/pkg/singbox/hysteria2.go
+++ b/pkg/singbox/hysteria2.go
@@ -3,16 +3,18 @@ package singbox
 import (
 	"context"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-box/outbound"
-	"github.com/sagernet/sing/common/logger"
 	"net"
 	"net/url"
 	"reflect"
 	"strconv"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+
+	"github.com/fatih/color"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/outbound"
+	"github.com/sagernet/sing/common/logger"
 )
 
 func NewHysteria2(link string) Protocol {

--- a/pkg/singbox/interface.go
+++ b/pkg/singbox/interface.go
@@ -2,7 +2,9 @@ package singbox
 
 import (
 	"context"
+
 	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+
 	"github.com/sagernet/sing-box/adapter"
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/logger"

--- a/pkg/singbox/protocol.go
+++ b/pkg/singbox/protocol.go
@@ -2,9 +2,10 @@ package singbox
 
 import (
 	"errors"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"net/url"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 )
 
 func (c *Core) CreateProtocol(configLink string) (protocol.Protocol, error) {

--- a/pkg/singbox/shadowsocks.go
+++ b/pkg/singbox/shadowsocks.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-box/outbound"
-	"github.com/sagernet/sing/common/logger"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/outbound"
+	"github.com/sagernet/sing/common/logger"
 )
 
 func NewShadowsocks(link string) Protocol {

--- a/pkg/singbox/singbox.go
+++ b/pkg/singbox/singbox.go
@@ -2,15 +2,17 @@ package singbox
 
 import (
 	"context"
+	"net"
+	"net/http"
+	"time"
+
 	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+
 	box "github.com/sagernet/sing-box"
 	"github.com/sagernet/sing-box/log"
 	"github.com/sagernet/sing-box/option"
 	"github.com/sagernet/sing/common/logger"
 	M "github.com/sagernet/sing/common/metadata"
-	"net"
-	"net/http"
-	"time"
 )
 
 type Core struct {

--- a/pkg/singbox/socks.go
+++ b/pkg/singbox/socks.go
@@ -4,19 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-box/outbound"
-	"github.com/sagernet/sing/common/logger"
 	"net"
 	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/outbound"
+	"github.com/sagernet/sing/common/logger"
 	"github.com/xtls/xray-core/infra/conf"
 )
 

--- a/pkg/singbox/trojan.go
+++ b/pkg/singbox/trojan.go
@@ -4,19 +4,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/lilendian0x00/xray-knife/v2/utils"
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-box/outbound"
-	"github.com/sagernet/sing/common/logger"
-	"github.com/xtls/xray-core/infra/conf"
 	"net"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/outbound"
+	"github.com/sagernet/sing/common/logger"
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 func NewTrojan(link string) Protocol {

--- a/pkg/singbox/vless.go
+++ b/pkg/singbox/vless.go
@@ -4,19 +4,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/lilendian0x00/xray-knife/v2/utils"
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-box/outbound"
-	"github.com/sagernet/sing/common/logger"
-	"github.com/xtls/xray-core/infra/conf"
 	"net"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/outbound"
+	"github.com/sagernet/sing/common/logger"
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 func NewVless(link string) Protocol {

--- a/pkg/singbox/vmess.go
+++ b/pkg/singbox/vmess.go
@@ -5,19 +5,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-box/outbound"
-	"github.com/sagernet/sing/common/logger"
-	"github.com/xtls/xray-core/infra/conf"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/outbound"
+	"github.com/sagernet/sing/common/logger"
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 func NewVmess(link string) Protocol {

--- a/pkg/singbox/wireguard.go
+++ b/pkg/singbox/wireguard.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/sagernet/sing-box/adapter"
-	"github.com/sagernet/sing-box/option"
-	"github.com/sagernet/sing-box/outbound"
-	"github.com/sagernet/sing/common/logger"
 	"net"
 	"net/netip"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+
+	"github.com/fatih/color"
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/outbound"
+	"github.com/sagernet/sing/common/logger"
 )
 
 func NewWireguard(link string) Protocol {

--- a/pkg/xray/interface.go
+++ b/pkg/xray/interface.go
@@ -2,6 +2,7 @@ package xray
 
 import (
 	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+
 	"github.com/xtls/xray-core/infra/conf"
 )
 

--- a/pkg/xray/protocol.go
+++ b/pkg/xray/protocol.go
@@ -2,9 +2,10 @@ package xray
 
 import (
 	"errors"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"net/url"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 )
 
 func (c *Core) CreateProtocol(configLink string) (protocol.Protocol, error) {

--- a/pkg/xray/shadowsocks.go
+++ b/pkg/xray/shadowsocks.go
@@ -4,13 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"net"
 	"net/url"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
 	"github.com/xtls/xray-core/infra/conf"
 )
 

--- a/pkg/xray/socks.go
+++ b/pkg/xray/socks.go
@@ -3,15 +3,16 @@ package xray
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"log"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
 	net2 "github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/infra/conf"
 )

--- a/pkg/xray/trojan.go
+++ b/pkg/xray/trojan.go
@@ -3,14 +3,16 @@ package xray
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/lilendian0x00/xray-knife/v2/utils"
-	"github.com/xtls/xray-core/infra/conf"
 	"net"
 	"net/url"
 	"reflect"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 func NewTrojan(link string) Protocol {

--- a/pkg/xray/utils.go
+++ b/pkg/xray/utils.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	xraynet "github.com/xtls/xray-core/common/net"
-	"github.com/xtls/xray-core/core"
 	"io"
 	"net"
 	"net/http"
 	"time"
+
+	xraynet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/core"
 )
 
 func MeasureDelay(inst *core.Instance, timeout time.Duration, showBody bool, dest string, httpMethod string) (int64, int, error) {

--- a/pkg/xray/vless.go
+++ b/pkg/xray/vless.go
@@ -3,14 +3,16 @@ package xray
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/lilendian0x00/xray-knife/v2/utils"
-	"github.com/xtls/xray-core/infra/conf"
 	"net"
 	"net/url"
 	"reflect"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 func NewVless(link string) Protocol {

--- a/pkg/xray/vmess.go
+++ b/pkg/xray/vmess.go
@@ -3,13 +3,14 @@ package xray
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"net"
 	"net/url"
 	"strings"
 
-	"github.com/fatih/color"
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
 	"github.com/lilendian0x00/xray-knife/v2/utils"
+
+	"github.com/fatih/color"
 	"github.com/xtls/xray-core/infra/conf"
 )
 

--- a/pkg/xray/wireguard.go
+++ b/pkg/xray/wireguard.go
@@ -3,12 +3,14 @@ package xray
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
-	"github.com/xtls/xray-core/infra/conf"
 	"net/url"
 	"reflect"
 	"strings"
+
+	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+
+	"github.com/fatih/color"
+	"github.com/xtls/xray-core/infra/conf"
 )
 
 func NewWireguard(link string) Protocol {

--- a/pkg/xray/xray.go
+++ b/pkg/xray/xray.go
@@ -3,7 +3,12 @@ package xray
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+	"time"
+
 	"github.com/lilendian0x00/xray-knife/v2/pkg/protocol"
+
 	"github.com/xtls/xray-core/app/dispatcher"
 	applog "github.com/xtls/xray-core/app/log"
 	"github.com/xtls/xray-core/app/proxyman"
@@ -11,9 +16,6 @@ import (
 	xraynet "github.com/xtls/xray-core/common/net"
 	"github.com/xtls/xray-core/common/serial"
 	"github.com/xtls/xray-core/core"
-	"net"
-	"net/http"
-	"time"
 
 	// The following deps are necessary as they register handlers in their init functions.
 	_ "github.com/xtls/xray-core/app/dispatcher"

--- a/speedtester/speedtest.go
+++ b/speedtester/speedtest.go
@@ -1,8 +1,9 @@
 package speedtester
 
 import (
-	"github.com/lilendian0x00/xray-knife/v2/speedtester/custom"
 	"net/http"
+
+	"github.com/lilendian0x00/xray-knife/v2/speedtester/custom"
 )
 
 type SpeedTester struct {

--- a/utils/customlog/log.go
+++ b/utils/customlog/log.go
@@ -1,8 +1,9 @@
 package customlog
 
 import (
-	"github.com/fatih/color"
 	"time"
+
+	"github.com/fatih/color"
 )
 
 type Type uint8


### PR DESCRIPTION
This PR fixes crashes that occur on various commands especially when using file input and multiple links.

- proxy's file input (both single and multi)
- parse's file input
- Enable AutomaticCore on some parts of Parse
- Better Error handling and visibility in net/http