### PR TITLE
Fix: trim spaces and validate host/SNI to prevent XHTTP panic

### DIFF
--- a/pkg/core/xray/vless.go
+++ b/pkg/core/xray/vless.go
@@ -56,7 +56,23 @@ func (v *Vless) Parse() error {
 	v.Type = query.Get("type")         // network type: "tcp", "ws", "grpc", "quic", etc.
 
 	// Validate host and sni parameters before assigning them
+
+    isValidHostName := func(s string) bool {
+        if s == "" {
+            return true
+        }
+        for _, r := range s {
+            if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '-') {
+                return false
+            }
+        }
+        return true
+    }
+
     sni := strings.TrimSpace(query.Get("sni"))
+    if !isValidHostName(sni) {
+        return fmt.Errorf("sni contains invalid characters (only letters, digits, dot, hyphen allowed): %s", sni)
+    }
     if strings.Contains(sni, " ") {
         return fmt.Errorf("sni contains space: %s", sni)
     }
@@ -65,6 +81,9 @@ func (v *Vless) Parse() error {
     }
 
     host := strings.TrimSpace(query.Get("host"))
+    if !isValidHostName(host) {
+        return fmt.Errorf("host contains invalid characters (only letters, digits, dot, hyphen allowed): %s", host)
+    }
     if strings.Contains(host, " ") {
         return fmt.Errorf("host contains space: %s", host)
     }

--- a/pkg/core/xray/vless.go
+++ b/pkg/core/xray/vless.go
@@ -56,15 +56,22 @@ func (v *Vless) Parse() error {
 	v.Type = query.Get("type")         // network type: "tcp", "ws", "grpc", "quic", etc.
 
 	// Validate host and sni parameters before assigning them
-	sni := query.Get("sni")
-	if !utils.IsValidHostOrSNI(sni) {
-		return fmt.Errorf("invalid characters in 'sni' parameter: %s", sni)
-	}
-	host := query.Get("host")
-	if !utils.IsValidHostOrSNI(host) {
-		return fmt.Errorf("invalid characters in 'host' parameter: %s", host)
-	}
+    sni := strings.TrimSpace(query.Get("sni"))
+    if strings.Contains(sni, " ") {
+        return fmt.Errorf("sni contains space: %s", sni)
+    }
+    if !utils.IsValidHostOrSNI(sni) {
+        return fmt.Errorf("invalid characters in 'sni' parameter: %s", sni)
+    }
 
+    host := strings.TrimSpace(query.Get("host"))
+    if strings.Contains(host, " ") {
+        return fmt.Errorf("host contains space: %s", host)
+    }
+    if !utils.IsValidHostOrSNI(host) {
+        return fmt.Errorf("invalid characters in 'host' parameter: %s", host)
+    }
+	
 	v.SNI = sni
 	v.Host = host                // for ws, http
 	v.Path = query.Get("path")   // for ws, http path, or kcp seed


### PR DESCRIPTION
When parsing VLESS links with XHTTP transport, trailing spaces in the 'host' query parameter (e.g., before '#') cause a nil pointer dereference panic. Other transports handle such malformed links gracefully.

This fix:
- Trims spaces from host and SNI parameters.
- Adds explicit validation for internal spaces (invalid for host/SNI).
- Returns clear error messages instead of crashing.

Tested with trailing spaces, internal spaces, and valid links. No panic observed.