### PR TITLE
feat: normalize CIDR notation for subnets in cfscanner and API handler

### DIFF
--- a/cmd/cfscanner/cfscanner.go
+++ b/cmd/cfscanner/cfscanner.go
@@ -43,6 +43,9 @@ pass a file containing one subnet per line.`,
 			customlog.Printf(customlog.Failure, "No subnets found. Please provide a valid file or CIDR list for the --subnets flag.\n")
 			return
 		}
+		for i, s := range allSubnets {
+			allSubnets[i] = utils.NormalizeCIDR(s)
+		}
 		cliConfig.Subnets = allSubnets
 
 		if cliConfig.Port <= 0 || cliConfig.Port > 65535 {

--- a/utils/ip.go
+++ b/utils/ip.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 )
 
 func incrementIP(i *net.IP) {
@@ -40,6 +41,21 @@ func CIDRSize(cidr string) (int, error) {
 	}
 	ones, bits := ipNet.Mask.Size()
 	return 1 << (bits - ones), nil
+}
+
+// NormalizeCIDR appends /32 or /128 to bare IPs missing a subnet mask.
+func NormalizeCIDR(s string) string {
+	if strings.Contains(s, "/") {
+		return s
+	}
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return s
+	}
+	if ip.To4() != nil {
+		return s + "/32"
+	}
+	return s + "/128"
 }
 
 func IsIPv6(ipStr string) bool {

--- a/web/api_handlers.go
+++ b/web/api_handlers.go
@@ -14,6 +14,7 @@ import (
 	pkghttp "github.com/lilendian0x00/xray-knife/v10/pkg/http"
 	"github.com/lilendian0x00/xray-knife/v10/pkg/proxy"
 	"github.com/lilendian0x00/xray-knife/v10/pkg/scanner"
+	"github.com/lilendian0x00/xray-knife/v10/utils"
 )
 
 // appendResultsToCSV delegates to the shared implementation in pkg/http.
@@ -229,6 +230,9 @@ func (h *APIHandler) handleCfScannerStart(w http.ResponseWriter, r *http.Request
 	if err := decodeJSONBody(w, r, &cfg); err != nil {
 		writeJSONError(w, fmt.Sprintf("Invalid request body: %v", err), http.StatusBadRequest)
 		return
+	}
+	for i, s := range cfg.Subnets {
+		cfg.Subnets[i] = utils.NormalizeCIDR(s)
 	}
 	if err := h.manager.StartScanner(cfg); err != nil {
 		writeJSONError(w, err.Error(), http.StatusConflict)


### PR DESCRIPTION
## Summary

When users provide bare IPs (e.g. `1.1.1.1` or `2606:4700::1`) to the CF scanner without a CIDR subnet mask, they were silently skipped because `net.ParseCIDR()` requires the `/mask` notation.

## Changes

- Added `NormalizeCIDR()` in `utils/ip.go` that appends `/32` for IPv4 or `/128` for IPv6 bare IPs, leaving existing CIDR notation unchanged
- Applied normalization in both CLI (`cmd/cfscanner/cfscanner.go`) and web API (`web/api_handlers.go`) entry points

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `1.1.1.1` | Skipped (parse error) | Scanned as `1.1.1.1/32` |
| `2606:4700::1` | Skipped (parse error) | Scanned as `2606:4700::1/128` |
| `1.1.1.0/24` | Works | Works (unchanged) |
