### PR TITLE
fix: vless detour config builder silently drops encryption param

### DIFF
--- a/pkg/core/xray/vless.go
+++ b/pkg/core/xray/vless.go
@@ -203,6 +203,12 @@ func (v *Vless) DetailsStr() string {
 		info += fmt.Sprintf("%s: none\n", color.RedString("TLS"))
 	}
 
+  if copyV.Encryption != "" {
+		info += fmt.Sprintf("%s: %s\n", color.RedString("Encryption"), copyV.Encryption)
+  } else {
+		info += fmt.Sprintf("%s: none\n", color.RedString("Encryption"))
+  }
+
 	return info
 }
 

--- a/pkg/core/xray/vless.go
+++ b/pkg/core/xray/vless.go
@@ -452,6 +452,9 @@ func (v *Vless) BuildOutboundDetourConfig(allowInsecure bool) (*conf.OutboundDet
 	if v.Flow != "" {
 		user["flow"] = v.Flow
 	}
+	if v.Encryption != "" {
+		user["encryption"] = v.Encryption
+	}
 	settingsBytes, err := json.Marshal(map[string]interface{}{
 		"vnext": []map[string]interface{}{
 			{


### PR DESCRIPTION
Encryption param isn't passed to xray config and parse output. Some links didn't work before my fix :(